### PR TITLE
Fix TsComponent

### DIFF
--- a/onboarding-task/src/components/List.jsx
+++ b/onboarding-task/src/components/List.jsx
@@ -10,7 +10,7 @@ class List extends Component {
         {/* TODO: You can delete the assignment part once you do not need it */}
         <div className="row">
           <div className="col-sm-12 text-center">
-            <TsComponent name="Fancy" />
+            <TsComponent name="𝕱𝖆𝖓𝖈𝖞" />
           </div>
         </div>
 

--- a/onboarding-task/src/components/TsComponent.tsx
+++ b/onboarding-task/src/components/TsComponent.tsx
@@ -7,9 +7,9 @@ interface ITsComponentProps {
 class TsComponent extends React.Component<ITsComponentProps, undefined> {
   render() {
     return (
-      <h1 className="text-danger">
-        Hello from <b>{this.props.name}</b> TypeScript component.
-      </h1>
+      <h3 className="text-danger" title="https://lingojam.com/FancyTextGenerator">
+        Ⓗⓔⓛⓛⓞ ⓕⓡⓞⓜ <b>{this.props.name}</b> [̲̅T][̲̅y][̲̅p][̲̅e][̲̅S][̲̅c][̲̅r][̲̅i][̲̅p][̲̅t] ⓒⓞⓜⓟⓞⓝⓔⓝⓣ
+      </h3>
     );
   }
 }

--- a/onboarding-task/src/components/TsComponent.tsx
+++ b/onboarding-task/src/components/TsComponent.tsx
@@ -7,8 +7,8 @@ interface ITsComponentProps {
 class TsComponent extends React.Component<ITsComponentProps, undefined> {
   render() {
     return (
-      <h1 style={{color: 'red'}}>
-        Hello from <b>{this.props.name}</b> TypeScript TypeScript component.
+      <h1 className="text-danger">
+        Hello from <b>{this.props.name}</b> TypeScript component.
       </h1>
     );
   }


### PR DESCRIPTION
Hi,

* I found two small details in Your fancy component. It could use bootstrap to color the heading red and the word "typescript" was duplicated (commit 546e40c).
* It was quite a small commit with only a small details in it, so I took my liberty to make your component even fancier (commit 8256616) more or less for fun :grinning: 
* Also, I was wondering about ``I`` prefix in interface names. I've read some other suggestions regards naming (such as this [SO](http://stackoverflow.com/a/41967120/1138663)) and [TS repository on GitHub](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines) forbids this practice to its contributors – is the prefix a rule we wanna push or just a habit or something even more, hm, fancy? :grimacing: 