### PR TITLE
Fix upstream setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ You won't be added as a contributor to this repository. You have to fork it to o
 3. In git bash:
  - `git clone http://github.com/your-login/kentico-onboarding-js` -- will init a local repo tracking your forked origin
  - `cd kentico-onboarding-js` -- changes directory to cloned repo
- - `git remote add --track master upstream git://github.com/suzii/kentico-onboarding-js` -- adds the original repository you forked from as a remote named 'upstream' so that you can receive updates by merging from it
- - `git fetch upstream` -- receive latest code
+ - `git remote add upstream git://github.com/suzii/kentico-onboarding-js` -- adds the original repository you forked from as a remote named 'upstream' so that you can receive updates by merging from it
+ - `git fetch upstream` -- receive latest code from the upstream's mater 
  - `git merge upstream/master` -- merge it to your own master
- - you now have the latest upstream code in your local master branch
- - `git checkout -b develop` -- creates and checkouts new branch named `develop` where you can continously work on the assignment. You should keep this branch one-to-one with the upstream repository branch `solutions/yourlogin`
- - `git checkout -b features/task-1` -- crates and checkouts new branch named `features/task-1` based on develop. Commit all your progress on Task 1 to this branch.
+ - You now have the latest upstream code in your local master branch
+ - `git checkout -b develop upstream/solutions/<your-login>` -- creates and checkouts new branch named `develop` where you can continuously work on the assignment.
+ - You should keep this branch one-to-one with the upstream repository branch `solutions/<your-login>;` 
+ - `git checkout -b feature/task-0` -- crates and checkouts new branch named `feature/task-0` based on `develop`. Commit all your progress on Task 0 to this branch.
  - Try to keep your `master` up to date with `upstream/master` and propagate the changes to all your branches.
  
 ### Pull Requests (PR)
@@ -60,7 +61,11 @@ ESlint and TSlint are already set-up for you, so you will see all the errors and
  - more Draft-specific coding rules are specified in https://kentico.atlassian.net/wiki/display/KA/04b+-+JS+Draft+Conventions+--+DRAFT
 
 ## Task 0
-In order to update your upstream solutions branch with the changes that might have happend on upstream master: After cloning the repository, create `develop` and then `feature/task-0` branch. Submit new Pull request to your solutions branch from task-0 branch.
+Update your upstream solutions branch with the changes that might have happened on upstream master: After cloning your repository, create `develop` and then `feature/task-0` branch (as described above).
+Merge your `master` branch - that already includes all changes from `upstream/master` - into task-0 branch and submit new Pull request to your solutions branch from task-0 branch.
+
+When your pull request gets merged into `upstream/solutions/<your-login>`, fetch new commits and merge them into your `develop` branch. Preferably use `--no-ff` option to enforce a merge commit, so it is easy to spot in the `develop` branch where a task starts and ends.
+You can then delete the `feature/task-0` branch and create a new one for the following task (`feature/task-1`).
 
 ## Task 1
 According to `assignment.gif` implement all the required functionality (keep in mind we want to be able to edit multiple list items at once). Store some pseudo-random identifier (id) for each item (use some util function for its generation, e.g: http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript)


### PR DESCRIPTION
The original ` --track master` only setup tracking for the single branch.
There were 2 options, either track all branches in the upstream repository or call `git remote branches --add <branch names>`. I decided to go for the first option as it is fewer commands to start with.

Then I updated the `develop` check-out to track upstream from the very beginning – this way, the git will show branch label in log (when `--decorate`d) and it seems to me that it demonstrates our purpose.

I also made the `task 0` description a bit more detailed, based on questions I got – hopefully, this will be clearer to anybody. I tried to encourage usage of `--no-ff` switch and branch deletion base on this [article](https://developer.atlassian.com/blog/2014/12/pull-request-merge-strategies-the-great-debate/) (and partially [this article](https://www.atlassian.com/git/articles/git-team-workflows-merge-or-rebase) from the same guy).